### PR TITLE
Update SciPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     platforms=['any'],
     install_requires=[
         "numpy >= 1.14.0",
-        "scipy >= 0.19.0",
+        "scipy >= 1.2.0",
         "pyDOE >= 0.3.8",
         "setuptools >= 38.6.0",
     ],


### PR DESCRIPTION
It doesn't work with SciPy 1.1.0, so I updated this dependency. Version 1.2.3 is the latest to work with Python 2 (maybe it would be worth dropping Python 2 now)