### PR TITLE
add encoding to io.open for windows compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/cjekel/piecewise_linear_fit_py',
     license='MIT License',
     description='fit piecewise linear functions to data',
-    long_description=io.open('README.rst').read(),
+    long_description=io.open('README.rst', encoding="utf-8").read(),
     # long_description_content_type='text/markdown',
     platforms=['any'],
     install_requires=[


### PR DESCRIPTION
For the conda-forge packaging efforts, we initially went with `noarch`, which means that only one package gets built, because the package shouldn't depend on any OS- or python-version-specific things (like compilers).

However, to accommodate the update for `2.0.1` in https://github.com/conda-forge/pwlf-feedstock/pull/1 (namely the distinction to use `importlib-metadata` only on `python>=3.8`), I had to disable the `noarch` setting, which meant that then all builds got done separately. This uncovered an error on windows, because `README.rst` apparently has some non-ASCII signs, and this fails because `io.open` on windows has a default of `encoding=cp1252`.

Fortunately, the fix is simple.