### PR TITLE
Avoids ignoring `seed=0`

### DIFF
--- a/pwlf/pwlf.py
+++ b/pwlf/pwlf.py
@@ -219,7 +219,7 @@ class PiecewiseLinFit(object):
             # self.weights2 = weights*weights
             self.y_w = np.dot(self.y_data, np.eye(self.n_data) * self.weights)
 
-        if seed:
+        if seed is not None:
             np.random.seed(seed)
         self.seed = seed
 


### PR DESCRIPTION
The old check `if seed:` ignored `seed=0`.
Instead, it should be checked whether `seed` is passed as an initialization parameter, i.e., `if seed is not None:`.