### PR TITLE
Restore scipy >= 1.18 compatibility (fixes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Restored compatibility with scipy >= 1.18 and removed the `scipy < 1.18.0` upper bound. scipy 1.18 changed `scipy.linalg.lstsq` to return a NaN residual (instead of raising `LinAlgError`) for rank-deficient/degenerate breakpoint locations, which produced NaN objective values that broke `fit`/`fitfast` (`np.nanargmin` "All-NaN slice"). The least-squares residual is now recomputed from `beta` whenever scipy returns a non-finite residual, and the optimization objective returns `np.inf` for any non-finite fit so the optimizer steers away from degenerate breakpoints. Also dropped the removed `iprint`/`disp` kwargs from a `fmin_l_bfgs_b` keyword-passthrough test. Fixes #134.
+
 ## [2.5.3] - 2026-06-28
 ### Changed
 - set scipy version to be less than 1.18. scipy 1.18 has broken a lot of pwlf with the changes to the optimization packages which we heavily depended upon.

--- a/pwlf/pwlf.py
+++ b/pwlf/pwlf.py
@@ -676,9 +676,10 @@ class PiecewiseLinFit(object):
             # on an error, return ssr = np.inf
             # You might have a singular Matrix!!!
             ssr = np.inf
-        if ssr is None:
+        if ssr is None or not np.isfinite(ssr):
+            # the fit is singular/degenerate (e.g. coincident breakpoints);
+            # return np.inf so the optimizer steers away from this location
             ssr = np.inf
-            # something went wrong...
         return ssr
 
     def fit_force_points_opt(self, var):
@@ -1658,7 +1659,12 @@ class PiecewiseLinFit(object):
         if isinstance(ssr, list):
             ssr = ssr
         elif isinstance(ssr, np.ndarray):
-            if ssr.size == 0:
+            # scipy.linalg.lstsq only returns the residual sum of squares
+            # when the system is overdetermined and full rank; otherwise it
+            # returns an empty array. As of scipy 1.18 it may also return
+            # NaN for rank-deficient/degenerate breakpoint locations even
+            # though beta is finite. In either case recompute ssr directly.
+            if ssr.size == 0 or not np.all(np.isfinite(ssr)):
                 y_hat = np.dot(A, beta)
                 e = y_hat - self.y_data
                 ssr = np.dot(e, e)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     platforms=["any"],
     install_requires=[
         "numpy >= 1.14.0",
-        "scipy >= 1.8.0, <1.18.0",
+        "scipy >= 1.8.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -305,15 +305,26 @@ class TestEverything(unittest.TestCase):
         my_pwlf = pwlf.PiecewiseLinFit(x, y)
         breaks = my_pwlf.fit_guess([6.0], m=10,
                                    factr=1e2, pgtol=1e-05,
-                                   epsilon=1e-6, iprint=-1,
-                                   maxfun=1500000, maxiter=150000,
-                                   disp=None)
+                                   epsilon=1e-6,
+                                   maxfun=1500000, maxiter=150000)
         self.assertTrue(np.isclose(breaks[1], 6.0705297))
 
     def test_multi_start_fitfast(self):
         my_pwlf = pwlf.PiecewiseLinFit(self.x_small, self.y_small)
         my_pwlf.fitfast(4, 50)
         self.assertTrue(np.isclose(my_pwlf.ssr, 0.0))
+
+    def test_degenerate_breaks_finite_ssr(self):
+        # scipy >= 1.18 returns a NaN residual (instead of raising
+        # LinAlgError) from linalg.lstsq when a trial produces degenerate
+        # breakpoints, e.g. an interior breakpoint on the domain boundary.
+        # The objective must still yield a finite ssr computed from beta,
+        # otherwise the NaN poisons fitfast's np.nanargmin (All-NaN slice)
+        # and the global optimization in fit(). See issue #134.
+        my_pwlf = pwlf.PiecewiseLinFit(self.x_sin, self.y_sin, degree=2)
+        breaks = my_pwlf.fitfast(3)
+        self.assertTrue(np.all(np.isfinite(breaks)))
+        self.assertTrue(np.isfinite(my_pwlf.ssr))
 
     # =================================================
     # Start of degree tests


### PR DESCRIPTION
Fixes #134.

## Problem

Under scipy 1.18, `fit()` and `fitfast()` break — `fitfast()` raises `ValueError: All-NaN slice encountered` and `fit()` can converge to wrong breakpoints. This reproduces the "seeing NaNs ... ~5 tests failing" you described in #134. On this branch, `python -m pytest tests/tests.py` under scipy 1.18.0 fails 5 tests on current `master`:

```
FAILED test_all_stats       - ValueError: All-NaN slice encountered
FAILED test_fit             - AssertionError
FAILED test_fit_guess       - AssertionError
FAILED test_fit_guess_kwrds - TypeError: fmin_l_bfgs_b() got an unexpected keyword argument 'iprint'
FAILED test_fitfast         - AssertionError
```

## Root cause

scipy 1.18 changed `scipy.linalg.lstsq`: for a **rank-deficient / degenerate** system it now returns a **`NaN` residual** instead of raising `LinAlgError` — and it does so *even when `beta` itself is finite*. This happens during optimization whenever a trial puts an interior breakpoint on the domain boundary (coincident breakpoints), e.g. `var = [4.52, 10.0]`:

```python
beta, ssr, rank, s = linalg.lstsq(A, y, lapack_driver="gelsd")
# scipy 1.17: raises LinAlgError (caught -> ssr=inf)
# scipy 1.18: rank=5, beta finite, ssr = array(nan)   <-- silent NaN
```

`lstsq()` only recomputed `ssr` manually when the residual array was *empty*, and `fit_with_breaks_opt()` only guarded against `LinAlgError`/`None` — so the `NaN` leaked into the objective. That `NaN` then poisons `fitfast`'s `np.nanargmin` (all trials `NaN` → "All-NaN slice") and misdirects the global optimization in `fit`.

## Fix

- **`lstsq()`** — recompute the residual sum of squares from `beta` whenever scipy returns a **non-finite** residual, mirroring the existing empty-residual path. Since `beta` is finite in the degenerate case, this yields the *correct* finite `ssr` (verified to match scipy's own residual exactly at non-degenerate points).
- **`fit_with_breaks_opt()`** — return `np.inf` for any non-finite fit, so the optimizer steers away from truly singular breakpoints (restores pre-1.18 behavior).
- **`setup.py`** — remove the temporary `scipy < 1.18.0` upper bound added in 2.5.3.
- **tests** — drop the `iprint`/`disp` kwargs (removed from `fmin_l_bfgs_b` in scipy 1.18) from the keyword-passthrough test, and add a regression test for the degenerate-breakpoint NaN case.

The change is inert on older scipy (the recompute only triggers when the returned residual is non-finite, which pre-1.18 never returns), so existing behavior is unchanged.

## Test evidence

All tests pass on both the new and previously-supported scipy:

| scipy | result |
|---|---|
| 1.18.0 | `63 passed` |
| 1.17.1 | `63 passed` |

(63 = the existing 62 plus the new `test_degenerate_breaks_finite_ssr` regression test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
